### PR TITLE
Update test for moq dwp controller

### DIFF
--- a/CheckYourEligibility.APIUnitTests/MoqDwpControllerTests.cs
+++ b/CheckYourEligibility.APIUnitTests/MoqDwpControllerTests.cs
@@ -119,7 +119,6 @@ namespace CheckYourEligibility.APIUnitTests
         }
 
         [Test]
-
         public void Given_Valid_Request_With_Non_Eligible_GUID_Should_Return_NotFoundResult()
         {
             //Arrange

--- a/CheckYourEligibility.APIUnitTests/MoqDwpControllerTests.cs
+++ b/CheckYourEligibility.APIUnitTests/MoqDwpControllerTests.cs
@@ -122,11 +122,12 @@ namespace CheckYourEligibility.APIUnitTests
         public void Given_Valid_Request_With_Non_Eligible_GUID_Should_Return_NotFoundResult()
         {
             //Arrange
+            var expectedResult = new NotFoundResult();
             //Act
             var response = _sut.Claim(MogDWPValues.validCitizenNotEligibleGuid, MogDWPValues.validUniversalBenefitType);
 
             //Assert
-            response.Result.Should().BeOfType(typeof(NotFoundResult));
+            response.Result.Should().BeEquivalentTo(expectedResult);
         }
     }
 }

--- a/CheckYourEligibility.APIUnitTests/MoqDwpControllerTests.cs
+++ b/CheckYourEligibility.APIUnitTests/MoqDwpControllerTests.cs
@@ -117,5 +117,17 @@ namespace CheckYourEligibility.APIUnitTests
             // Assert
             response.Result.Should().BeOfType(typeof(BadRequestResult));
         }
+
+        [Test]
+
+        public void Given_Valid_Request_With_Non_Eligible_GUID_Should_Return_NotFoundResult()
+        {
+            //Arrange
+            //Act
+            var response = _sut.Claim(MogDWPValues.validCitizenNotEligibleGuid, MogDWPValues.validUniversalBenefitType);
+
+            //Assert
+            response.Result.Should().BeOfType(typeof(NotFoundResult));
+        }
     }
 }


### PR DESCRIPTION
Adding a test that given a valid request with non eligible GUID the claim will return NotFoundResult.