### PR TITLE
limit bulk upload

### DIFF
--- a/CheckYourEligibility.APIUnitTests/EligibilityCheckControllerTests.cs
+++ b/CheckYourEligibility.APIUnitTests/EligibilityCheckControllerTests.cs
@@ -31,7 +31,7 @@ namespace CheckYourEligibility.APIUnitTests
             _mockLogger = Mock.Of<ILogger<EligibilityCheckController>>();
             var configForBulkUpload = new Dictionary<string, string>
             {
-                {"BulkUploadCheckRecordCountLimit", "5"},
+                {"BulkEligibilityCheckLimit", "5"},
             };
             _configuration = new ConfigurationBuilder()
                 .AddInMemoryCollection(configForBulkUpload)
@@ -223,7 +223,7 @@ namespace CheckYourEligibility.APIUnitTests
         {
             // Arrange
             var request = new CheckEligibilityRequestBulk_Fsm();
-            var limit = _configuration.GetValue<int>("BulkUploadCheckRecordCountLimit");
+            var limit = _configuration.GetValue<int>("BulkEligibilityCheckLimit");
             var requests = _fixture.CreateMany<CheckEligibilityRequestData_Fsm>(limit + 1);
             request.Data = requests;
 

--- a/CheckYourEligibility.APIUnitTests/MoqDwpControllerTests.cs
+++ b/CheckYourEligibility.APIUnitTests/MoqDwpControllerTests.cs
@@ -11,6 +11,7 @@ using FluentAssertions;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.HttpResults;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
 using Moq;
 using NUnit.Framework.Internal;
@@ -19,6 +20,7 @@ namespace CheckYourEligibility.APIUnitTests
 {
     public class MoqDwpControllerTests : TestBase.TestBase
     {
+        private IConfigurationRoot _configuration;
         private Mock<ICheckEligibility> _mockService;
         private ILogger<EligibilityCheckController> _mockLogger;
         private MoqDWPController _sut;
@@ -26,6 +28,13 @@ namespace CheckYourEligibility.APIUnitTests
         [SetUp]
         public void Setup()
         {
+            var configForBulkUpload = new Dictionary<string, string>
+            {
+                {"BulkUploadCheckRecordCountLimit", "5"},
+            };
+            _configuration = new ConfigurationBuilder()
+                .AddInMemoryCollection(configForBulkUpload)
+                .Build();
             _mockService = new Mock<ICheckEligibility>(MockBehavior.Strict);
             _mockLogger = Mock.Of<ILogger<EligibilityCheckController>>();
             _sut = new MoqDWPController(_mockLogger, _mockService.Object);
@@ -44,9 +53,10 @@ namespace CheckYourEligibility.APIUnitTests
             ICheckEligibility checkService = null;
             IApplication applicationService = null;
             IAudit auditService = null;
+          
 
             // Act
-            Action act = () => new EligibilityCheckController(_mockLogger, checkService,  auditService);
+            Action act = () => new EligibilityCheckController(_mockLogger, checkService,  auditService,_configuration);
 
             // Assert
             act.Should().ThrowExactly<ArgumentNullException>().And.Message.Should().EndWithEquivalentOf("Value cannot be null. (Parameter 'checkService')");

--- a/CheckYourEligibility.APIUnitTests/MoqDwpControllerTests.cs
+++ b/CheckYourEligibility.APIUnitTests/MoqDwpControllerTests.cs
@@ -30,7 +30,7 @@ namespace CheckYourEligibility.APIUnitTests
         {
             var configForBulkUpload = new Dictionary<string, string>
             {
-                {"BulkUploadCheckRecordCountLimit", "5"},
+                {"BulkEligibilityCheckLimit", "5"},
             };
             _configuration = new ConfigurationBuilder()
                 .AddInMemoryCollection(configForBulkUpload)

--- a/CheckYourEligibility.WebApp/Controllers/EligibilityController.cs
+++ b/CheckYourEligibility.WebApp/Controllers/EligibilityController.cs
@@ -34,7 +34,7 @@ namespace CheckYourEligibility.WebApp.Controllers
         {
             _logger = Guard.Against.Null(logger);
             _checkService = Guard.Against.Null(checkService);
-            _bulkUploadRecordCountLimit = configuration.GetValue<int>("BulkUploadCheckRecordCountLimit");
+            _bulkUploadRecordCountLimit = configuration.GetValue<int>("BulkEligibilityCheckLimit");
         }
 
         /// <summary>

--- a/CheckYourEligibility.WebApp/Controllers/EligibilityController.cs
+++ b/CheckYourEligibility.WebApp/Controllers/EligibilityController.cs
@@ -1,4 +1,5 @@
 ﻿using Ardalis.GuardClauses;
+using CheckYourEligibility.Data.Migrations.Migrations;
 using CheckYourEligibility.Domain.Exceptions;
 using CheckYourEligibility.Domain.Requests;
 using CheckYourEligibility.Domain.Responses;
@@ -25,13 +26,15 @@ namespace CheckYourEligibility.WebApp.Controllers
         private readonly ICheckEligibility _checkService;
         
         private readonly ILogger<EligibilityCheckController> _logger;
+        private readonly int _bulkUploadRecordCountLimit;
 
 
-        public EligibilityCheckController(ILogger<EligibilityCheckController> logger, ICheckEligibility checkService, IAudit audit)
+        public EligibilityCheckController(ILogger<EligibilityCheckController> logger, ICheckEligibility checkService, IAudit audit, IConfiguration configuration)
             : base( audit)
         {
             _logger = Guard.Against.Null(logger);
             _checkService = Guard.Against.Null(checkService);
+            _bulkUploadRecordCountLimit = configuration.GetValue<int>("BulkUploadCheckRecordCountLimit");
         }
 
         /// <summary>
@@ -68,6 +71,10 @@ namespace CheckYourEligibility.WebApp.Controllers
                 if (model == null || model.Data == null)
                 {
                     return BadRequest(new MessageResponse { Data = "Invalid Request, data is required." });
+                }
+                if (model.Data.Count()> _bulkUploadRecordCountLimit)
+                {
+                    return BadRequest(new MessageResponse { Data = $"Invalid Request, data limit of {_bulkUploadRecordCountLimit} exceeded, {model.Data.Count()} records."});
                 }
 
                 return await ProcessBulk(model);

--- a/CheckYourEligibility.WebApp/appsettings.json
+++ b/CheckYourEligibility.WebApp/appsettings.json
@@ -23,7 +23,7 @@
 
   "DataCleanseDaysSoftCheck_Status_eligible": 7,
   "DataCleanseDaysSoftCheck_Status_parentNotFound": 3,
-  "BulkUploadCheckRecordCountLimit": 250,
+  "BulkEligibillityCheckLimit": 250,
   "Dwp": {
     "BaseUrl": "",
     "ApiControllerUrl": "/MoqDWP",

--- a/CheckYourEligibility.WebApp/appsettings.json
+++ b/CheckYourEligibility.WebApp/appsettings.json
@@ -23,6 +23,7 @@
 
   "DataCleanseDaysSoftCheck_Status_eligible": 7,
   "DataCleanseDaysSoftCheck_Status_parentNotFound": 3,
+  "BulkUploadCheckRecordCountLimit": 250,
   "Dwp": {
     "BaseUrl": "",
     "ApiControllerUrl": "/MoqDWP",


### PR DESCRIPTION
Added appsettings value for BulkUploadCheckRecordCountLimit defaulted to 250, if the count of checks exceeds this then a badrequest is returned